### PR TITLE
fix: barArray should be a static array

### DIFF
--- a/docs/pages/store/reading-and-writing.mdx
+++ b/docs/pages/store/reading-and-writing.mdx
@@ -36,7 +36,7 @@ tables: {
 ```solidity
 // Setting a record
 uint256[] memory fooArray = new uint256[](1);
-uint256[] memory barArray = new uint256[](2);
+uint256[2] memory barArray;
 barArray[0] = 69;
 barArray[1] = 85;
 fooArray[0] = 42


### PR DESCRIPTION
If this is not a static array it will throw the error

```
➜  contracts git:(main) ✗ forge test
[⠆] Compiling...
[⠢] Compiling 5 files with 0.8.13
[⠆] Solc 0.8.13 finished in 899.89ms
Error:
Compiler run failed:
Error (9582): Member "set" not found or not visible after argument-dependent lookup in type(library MyTable).
  --> src/systems/MyTableSystem.sol:23:5:
   |
23 |     MyTable.set(keccak256("some.key"), 45, false, fooArray, barArray);
   |     ^^^^^^^^^^^
```